### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Mattermost Android Application for use with Mattermost server 2.1 and higher (http://www.mattermost.org/download/).
 
-> Note: The Mattermost Android App requires APIs being introduced in Mattermsot 2.1, which releases on March 16, 2016. You can test Android app functionality by joining the nightly builds server at https://pre-release.mattermost.com/core or by compiling [Mattermost platform](https://github.com/mattermost/platform) from the latest source code. 
+> Note: The Mattermost Android App requires APIs being introduced in Mattermost 2.1, which releases on March 16, 2016. You can test Android app functionality by joining the nightly builds server at https://pre-release.mattermost.com/core or by compiling [Mattermost platform](https://github.com/mattermost/platform) from the latest source code. 
 
 #### Beta Testing
 


### PR DESCRIPTION
There was a typo in the blurb warning about needing new APIs.