### PR TITLE
PLT-3435 Fixed expired session deviceId, and some UI changes

### DIFF
--- a/app/src/main/java/com/mattermost/mattermost/MainActivity.java
+++ b/app/src/main/java/com/mattermost/mattermost/MainActivity.java
@@ -258,6 +258,11 @@ public class MainActivity extends WebViewActivity {
                     }
                 }
 
+                // Check if deviceID is missing
+                if (url.toLowerCase().contains("/login")) {
+                    MattermostService.service.SetAttached(false);
+                }
+
                 // Check to see if the user was trying to logout
                 if (url.toLowerCase().endsWith("/logout")) {
                     MattermostApplication.handler.post(new Runnable() {

--- a/app/src/main/java/com/mattermost/service/MattermostService.java
+++ b/app/src/main/java/com/mattermost/service/MattermostService.java
@@ -178,6 +178,10 @@ public class MattermostService {
         preferences.edit().putString("AttachedId", "true").commit();
     }
 
+    public void SetAttached(boolean attached) {
+        preferences.edit().putString("AttachedId", "" + attached).commit();
+    }
+
     public String GetLastPath() {
         return preferences.getString("LastPath", "");
     }

--- a/app/src/main/res/layout/activity_select_server.xml
+++ b/app/src/main/res/layout/activity_select_server.xml
@@ -30,16 +30,50 @@
             android:layout_gravity="center_horizontal"
             android:layout_margin="10dp" />
 
-        <EditText
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/server_name"
-            android:layout_gravity="center_horizontal"
-            android:layout_margin="10dp"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:hint="@string/team_url_hint"
-            android:text="@string/team_url"
-            android:inputType="textNoSuggestions" />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+            <RelativeLayout
+                android:layout_width="0dp"
+                android:layout_height="fill_parent"
+                android:layout_weight="0.7">
+
+                <Spinner
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="20dp"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginLeft="10dp"
+                    android:id="@+id/server_prefix"
+                    android:layout_gravity="center_horizontal"
+                    android:textAppearance="?android:attr/textAppearanceListItemSmall"
+                    android:entries="@array/server_prefixs"
+                    />
+
+            </RelativeLayout>
+
+            <RelativeLayout
+                android:layout_weight="0.3"
+                android:layout_width="0dp"
+                android:layout_height="fill_parent">
+
+                <EditText
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/server_name"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_margin="10dp"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:hint="@string/team_url_hint"
+                    android:text="@string/team_url"
+                    android:imeOptions="actionGo"
+                    android:inputType="textUri|textNoSuggestions" />
+
+            </RelativeLayout>
+
+        </LinearLayout>
 
         <TextView
             android:layout_width="wrap_content"
@@ -52,7 +86,7 @@
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Proceed"
+            android:text="@string/select_server_button"
             android:id="@+id/proceed"
             android:layout_gravity="center_horizontal"
             android:layout_margin="10dp" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,7 +2,7 @@
 <resources>
     <color name="colorPrimary">#3F51B5</color>
     <color name="colorPrimaryDark">#303F9F</color>
-    <color name="colorAccent">#FF4081</color>
+    <color name="colorAccent">#1F7BC1</color>
     <color name="errorColor">#d50000</color>
     <color name="primary_text_material_light">#ffffff</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="welcome_text">Enter Mattermost Server URL</string>
     <string name="error_server_url_empty">Server URL cannot be empty</string>
     <string name="error_server_url">The server does not exist</string>
-    <string name="error_mattermost_server">The address does not appear to be a Mattermost server</string>
+    <string name="error_mattermost_server">We could not connect to the Mattermost server or the server is running an incompatible version.</string>
     <string name="login_sub_title">Email address for %s</string>
     <string name="uploads_disabled">File uploads are disabled.</string>
     <string name="choose_upload">Choose file for upload</string>
@@ -14,5 +14,10 @@
     <string name="error_retry">You may be offline or the Mattermost server you are trying to connect to is experiencing problems.</string>
     <string name="error_refresh">Refresh</string>
     <string name="error_logout">Logout</string>
-    <string name="team_url_hint">e.g. https://server.com</string>
+    <string name="team_url_hint">e.g. mattermost.server.com</string>
+    <string name="select_server_button">Proceed</string>
+    <string-array name="server_prefixs">
+        <item>https://</item>
+        <item>http://</item>
+    </string-array>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
- Fixed deviceId not set upon session expiry
- Changed login button and login colors to a light blue instead of pink (1)
- Added dropdown for `https://` or `http://` defaulting to `https://` (2)
- Changed server select textbox to be an URL, taking advantage of the Android keyboard (3)
- Added string changed in https://github.com/mattermost/android/pull/21
- Upgraded gradle to the latest version `2.1.2` from `1.5.0`

Screenshot 1
![image](https://cloud.githubusercontent.com/assets/5740966/16732725/8a8e90bc-474c-11e6-96c8-b3506f91ffdf.png)

Screenshot 2
![image](https://cloud.githubusercontent.com/assets/5740966/16732746/9779c724-474c-11e6-8444-6e23c4d1f1b0.png)

Screenshot 3
![screenshot_2016-07-11-09-49-14](https://cloud.githubusercontent.com/assets/5740966/16732812/e7ad7af6-474c-11e6-9d51-7ee6a32580d7.png)
