### PR TITLE
Added compatibility for Chromebooks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mattermost.mattermost">
-
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA" />
+	<!-- for chromebooks -->
+    <uses-permission android:name="android.permission.CAMERA" android:required="false"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />


### PR DESCRIPTION
Source:
https://github.com/mattermost/android/blob/master/app/src/main/AndroidManifest.xml
incompatible permissions may be set to be not required for
Chromebooks-->
android:required=["false"]
Chromebook incompatible permissions:
https://developer.android.com/topic/arc/manifest.html
How to make permissions optional:
https://developer.android.com/guide/topics/manifest/uses-feature-element.html